### PR TITLE
商品詳細表示機能の実装完了

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,12 +1,12 @@
 class ApplicationController < ActionController::Base
   before_action :basic_auth
   before_action :configure_permitted_parameters, if: :devise_controller?
- 
+
   private
 
   def basic_auth
     authenticate_or_request_with_http_basic do |username, password|
-      username == ENV["BASIC_AUTH_USER"] && password == ENV["BASIC_AUTH_PASSWORD"]  # 環境変数を読み込む記述に変更
+      username == ENV['BASIC_AUTH_USER'] && password == ENV['BASIC_AUTH_PASSWORD']  # 環境変数を読み込む記述に変更
     end
   end
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,8 +1,8 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show]
-  
+
   def index
-    @items = Item.includes(:user).order("created_at DESC")
+    @items = Item.includes(:user).order('created_at DESC')
   end
 
   def new
@@ -18,10 +18,16 @@ class ItemsController < ApplicationController
     end
   end
 
+  def show
+    @item = Item.find(params[:id])
+  end
+
+  def edit
+  end
+
   private
-  
+
   def item_params
     params.require(:item).permit(:name, :text, :category_id, :condition_id, :fee_id, :prefecture_id, :send_time_id, :price, :image).merge(user_id: current_user.id)
   end
-
 end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,16 +1,16 @@
 class Category < ActiveHash::Base
   self.data = [
     { id: 1,  name: '---' },
-    { id: 2,  name: 'レディース'},
-    { id: 3,  name: 'メンズ'},
-    { id: 4,  name: 'ベビー・キッズ'},
-    { id: 5,  name: 'インテリア・住まい・小物'},
-    { id: 6,  name: '本・音楽・ゲーム'},
-    { id: 7,  name: 'おもちゃ・ホビー・グッズ'},
-    { id: 8,  name: '家電・スマホ・カメラ'},
-    { id: 9,  name: 'スポーツ・レジャー'},
-    { id: 10, name: 'ハンドメイド'},
-    { id: 11, name: 'その他'}
+    { id: 2,  name: 'レディース' },
+    { id: 3,  name: 'メンズ' },
+    { id: 4,  name: 'ベビー・キッズ' },
+    { id: 5,  name: 'インテリア・住まい・小物' },
+    { id: 6,  name: '本・音楽・ゲーム' },
+    { id: 7,  name: 'おもちゃ・ホビー・グッズ' },
+    { id: 8,  name: '家電・スマホ・カメラ' },
+    { id: 9,  name: 'スポーツ・レジャー' },
+    { id: 10, name: 'ハンドメイド' },
+    { id: 11, name: 'その他' }
   ]
 
   include ActiveHash::Associations

--- a/app/models/condition.rb
+++ b/app/models/condition.rb
@@ -1,12 +1,12 @@
 class Condition < ActiveHash::Base
   self.data = [
     { id: 1,  name: '---' },
-    { id: 2,  name: '新品・未使用'},
-    { id: 3,  name: '未使用に近い'},
-    { id: 4,  name: '目がった傷や汚れなし'},
-    { id: 5,  name: 'やや傷や汚れあり'},
-    { id: 6,  name: '傷や汚れあり'},
-    { id: 7,  name: '全体的に状態が悪い'}
+    { id: 2,  name: '新品・未使用' },
+    { id: 3,  name: '未使用に近い' },
+    { id: 4,  name: '目がった傷や汚れなし' },
+    { id: 5,  name: 'やや傷や汚れあり' },
+    { id: 6,  name: '傷や汚れあり' },
+    { id: 7,  name: '全体的に状態が悪い' }
   ]
 
   include ActiveHash::Associations

--- a/app/models/fee.rb
+++ b/app/models/fee.rb
@@ -1,8 +1,8 @@
 class Fee < ActiveHash::Base
   self.data = [
     { id: 1,  name: '---' },
-    { id: 2,  name: '着払い（購入者負担）'},
-    { id: 3,  name: '送料込み（出品者負担）'}
+    { id: 2,  name: '着払い（購入者負担）' },
+    { id: 3,  name: '送料込み（出品者負担）' }
   ]
 
   include ActiveHash::Associations

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -16,7 +16,7 @@ class Item < ApplicationRecord
     validates :price
   end
 
-  with_options numericality: { other_than: 1, message: 'Select'}  do
+  with_options numericality: { other_than: 1, message: 'Select' } do
     validates :category_id
     validates :condition_id
     validates :fee_id
@@ -24,10 +24,10 @@ class Item < ApplicationRecord
     validates :send_time_id
   end
 
-  validates :price, format: { with: /([0-9].*[0-9])/ , message: 'Half-width number'}
-  validates :price, numericality: { only_integer:true, greater_than: 299, less_than: 10000000, message: 'Out of setting range'}
+  validates :price, format: { with: /([0-9].*[0-9])/, message: 'Half-width number' }
+  validates :price, numericality: { only_integer: true, greater_than: 299, less_than: 10_000_000, message: 'Out of setting range' }
 
   def was_attached?
-    self.image.attached?
+    image.attached?
   end
 end

--- a/app/models/prefecture.rb
+++ b/app/models/prefecture.rb
@@ -1,21 +1,21 @@
 class Prefecture < ActiveHash::Base
   self.data = [
-    {id: 1, name: '---'}, {id: 2, name: '北海道'}, {id: 3, name: '青森県'},
-    {id: 4, name: '岩手県'},{id: 5, name: '宮城県'}, {id: 6, name: '秋田県'},
-    {id: 7, name: '山形県'},{id: 8, name: '福島県'}, {id: 9, name: '茨城県'},
-    {id: 10, name: '栃木県'},{id: 11, name: '群馬県'}, {id: 12, name: '埼玉県'},
-    {id: 13, name: '千葉県'},{id: 14, name: '東京都'}, {id: 15, name: '神奈川県'},
-    {id: 16, name: '新潟県'}, {id: 17, name: '富山県'}, {id: 18, name: '石川県'},
-    {id: 19, name: '福井県'},{id: 20, name: '山梨県'}, {id: 21, name: '長野県'},
-    {id: 22, name: '岐阜県'},{id: 23, name: '静岡県'}, {id: 24, name: '愛知県'},
-    {id: 25, name: '三重県'},{id: 26, name: '滋賀県'}, {id: 27, name: '京都府'},
-    {id: 28, name: '大阪府'},{id: 29, name: '兵庫県'}, {id: 30, name: '奈良県'},
-    {id: 31, name: '和歌山県'},{id: 32, name: '鳥取県'}, {id: 33, name: '島根県'},
-    {id: 34, name: '岡山県'},{id: 35, name: '広島県'}, {id: 36, name: '山口県'},
-    {id: 37, name: '徳島県'},{id: 38, name: '香川県'}, {id: 39, name: '愛媛県'},
-    {id: 40, name: '高知県'},{id: 41, name: '福岡県'}, {id: 42, name: '佐賀県'},
-    {id: 43, name: '長崎県'},{id: 44, name: '熊本県'}, {id: 45, name: '大分県'},
-    {id: 46, name: '宮崎県'},{id: 47, name: '鹿児島県'}, {id: 48, name: '沖縄県'}
+    { id: 1, name: '---' }, { id: 2, name: '北海道' }, { id: 3, name: '青森県' },
+    { id: 4, name: '岩手県' }, { id: 5, name: '宮城県' }, { id: 6, name: '秋田県' },
+    { id: 7, name: '山形県' }, { id: 8, name: '福島県' }, { id: 9, name: '茨城県' },
+    { id: 10, name: '栃木県' }, { id: 11, name: '群馬県' }, { id: 12, name: '埼玉県' },
+    { id: 13, name: '千葉県' }, { id: 14, name: '東京都' }, { id: 15, name: '神奈川県' },
+    { id: 16, name: '新潟県' }, { id: 17, name: '富山県' }, { id: 18, name: '石川県' },
+    { id: 19, name: '福井県' }, { id: 20, name: '山梨県' }, { id: 21, name: '長野県' },
+    { id: 22, name: '岐阜県' }, { id: 23, name: '静岡県' }, { id: 24, name: '愛知県' },
+    { id: 25, name: '三重県' }, { id: 26, name: '滋賀県' }, { id: 27, name: '京都府' },
+    { id: 28, name: '大阪府' }, { id: 29, name: '兵庫県' }, { id: 30, name: '奈良県' },
+    { id: 31, name: '和歌山県' }, { id: 32, name: '鳥取県' }, { id: 33, name: '島根県' },
+    { id: 34, name: '岡山県' }, { id: 35, name: '広島県' }, { id: 36, name: '山口県' },
+    { id: 37, name: '徳島県' }, { id: 38, name: '香川県' }, { id: 39, name: '愛媛県' },
+    { id: 40, name: '高知県' }, { id: 41, name: '福岡県' }, { id: 42, name: '佐賀県' },
+    { id: 43, name: '長崎県' }, { id: 44, name: '熊本県' }, { id: 45, name: '大分県' },
+    { id: 46, name: '宮崎県' }, { id: 47, name: '鹿児島県' }, { id: 48, name: '沖縄県' }
   ]
 
   include ActiveHash::Associations

--- a/app/models/send_time.rb
+++ b/app/models/send_time.rb
@@ -1,9 +1,9 @@
 class SendTime < ActiveHash::Base
   self.data = [
     { id: 1,  name: '---' },
-    { id: 2,  name: '1~2日'},
-    { id: 3,  name: '2~3日'},
-    { id: 4,  name: '4~7日'}
+    { id: 2,  name: '1~2日' },
+    { id: 3,  name: '2~3日' },
+    { id: 4,  name: '4~7日' }
   ]
 
   include ActiveHash::Associations

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,19 +10,16 @@ class User < ApplicationRecord
     validates :nick_name
     validates :birth
 
-    with_options format: { with: /\A[一-龥ぁ-ん]/, message: 'Full-width characters'} do
+    with_options format: { with: /\A[一-龥ぁ-ん]/, message: 'Full-width characters' } do
       validates :last_name
       validates :first_name
     end
-  
-    with_options format: { with: /\A[ァ-ヶー－]+\z/, message: 'kana Full-width katakana characters'} do
+
+    with_options format: { with: /\A[ァ-ヶー－]+\z/, message: 'kana Full-width katakana characters' } do
       validates :last_reading
       validates :first_reading
     end
   end
 
-  validates :password, length: { minimum: 6 }, format: { with: /([0-9].*[a-zA-Z]|[a-zA-Z].*[0-9])/, message: 'Include both letters and numbers'}
-
+  validates :password, length: { minimum: 6 }, format: { with: /([0-9].*[a-zA-Z]|[a-zA-Z].*[0-9])/, message: 'Include both letters and numbers' }
 end
-  
-

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -1,0 +1,161 @@
+<%# cssは商品出品のものを併用しています。
+app/assets/stylesheets/items/new.css %>
+
+<div class="items-sell-contents">
+  <header class="items-sell-header">
+    <%= link_to image_tag('furima-logo-color.png' , size: '185x50'), "/" %>
+  </header>
+  <div class="items-sell-main">
+    <h2 class="items-sell-title">商品の情報を入力</h2>
+    <%= form_with local: true do |f| %>
+
+    <%# インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
+    <%# render 'shared/error_messages', model: f.object %>
+    <%# //インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
+
+    <%# 出品画像 %>
+    <div class="img-upload">
+      <div class="weight-bold-text">
+        出品画像
+        <span class="indispensable">必須</span>
+      </div>
+      <div class="click-upload">
+        <p>
+          クリックしてファイルをアップロード
+        </p>
+        <%= f.file_field :hoge, id:"item-image" %>
+      </div>
+    </div>
+    <%# /出品画像 %>
+    <%# 商品名と商品説明 %>
+    <div class="new-items">
+      <div class="weight-bold-text">
+        商品名
+        <span class="indispensable">必須</span>
+      </div>
+      <%= f.text_area :hoge, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
+      <div class="items-explain">
+        <div class="weight-bold-text">
+          商品の説明
+          <span class="indispensable">必須</span>
+        </div>
+        <%= f.text_area :hoge, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
+      </div>
+    </div>
+    <%# /商品名と商品説明 %>
+
+    <%# 商品の詳細 %>
+    <div class="items-detail">
+      <div class="weight-bold-text">商品の詳細</div>
+      <div class="form">
+        <div class="weight-bold-text">
+          カテゴリー
+          <span class="indispensable">必須</span>
+        </div>
+        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-category"}) %>
+        <div class="weight-bold-text">
+          商品の状態
+          <span class="indispensable">必須</span>
+        </div>
+        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-sales-status"}) %>
+      </div>
+    </div>
+    <%# /商品の詳細 %>
+
+    <%# 配送について %>
+    <div class="items-detail">
+      <div class="weight-bold-text question-text">
+        <span>配送について</span>
+        <a class="question" href="#">?</a>
+      </div>
+      <div class="form">
+        <div class="weight-bold-text">
+          配送料の負担
+          <span class="indispensable">必須</span>
+        </div>
+        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
+        <div class="weight-bold-text">
+          発送元の地域
+          <span class="indispensable">必須</span>
+        </div>
+        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-prefecture"}) %>
+        <div class="weight-bold-text">
+          発送までの日数
+          <span class="indispensable">必須</span>
+        </div>
+        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
+      </div>
+    </div>
+    <%# /配送について %>
+
+    <%# 販売価格 %>
+    <div class="sell-price">
+      <div class="weight-bold-text question-text">
+        <span>販売価格<br>(¥300〜9,999,999)</span>
+        <a class="question" href="#">?</a>
+      </div>
+      <div>
+        <div class="price-content">
+          <div class="price-text">
+            <span>価格</span>
+            <span class="indispensable">必須</span>
+          </div>
+          <span class="sell-yen">¥</span>
+          <%= f.text_field :hoge, class:"price-input", id:"item-price", placeholder:"例）300" %>
+        </div>
+        <div class="price-content">
+          <span>販売手数料 (10%)</span>
+          <span>
+            <span id='add-tax-price'></span>円
+          </span>
+        </div>
+        <div class="price-content">
+          <span>販売利益</span>
+          <span>
+            <span id='profit'></span>円
+          </span>
+        </div>
+      </div>
+    </div>
+    <%# /販売価格 %>
+
+    <%# 注意書き %>
+    <div class="caution">
+      <p class="sentence">
+        <a href="#">禁止されている出品、</a>
+        <a href="#">行為</a>
+        を必ずご確認ください。
+      </p>
+      <p class="sentence">
+        またブランド品でシリアルナンバー等がある場合はご記載ください。
+        <a href="#">偽ブランドの販売</a>
+        は犯罪であり処罰される可能性があります。
+      </p>
+      <p class="sentence">
+        また、出品をもちまして
+        <a href="#">加盟店規約</a>
+        に同意したことになります。
+      </p>
+    </div>
+    <%# /注意書き %>
+    <%# 下部ボタン %>
+    <div class="sell-btn-contents">
+      <%= f.submit "変更する" ,class:"sell-btn" %>
+      <%=link_to 'もどる', "#", class:"back-btn" %>
+    </div>
+    <%# /下部ボタン %>
+  </div>
+  <% end %>
+
+  <footer class="items-sell-footer">
+    <ul class="menu">
+      <li><a href="#">プライバシーポリシー</a></li>
+      <li><a href="#">フリマ利用規約</a></li>
+      <li><a href="#">特定商取引に関する表記</a></li>
+    </ul>
+    <%= link_to image_tag('furima-logo-color.png' , size: '185x50'), "/" %>
+    <p class="inc">
+      ©︎Furima,Inc.
+    </p>
+  </footer>
+</div>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -128,7 +128,7 @@
 
      <% @items.each do |item| %> 
       <li class='list'>
-        <%= link_to "#" do %>
+        <%= link_to item_path(item.id) do %>
         <div class='item-img-content'>
           <%= image_tag(item.image, class: "item-img") %>
           <%# 商品が売れていればsold outを表示しましょう %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -1,0 +1,111 @@
+<%= render "shared/header" %>
+
+<%# 商品の概要 %>
+<div class="item-show">
+  <div class="item-box">
+    <h2 class="name">
+      <%= @item.name %>
+    </h2>
+    <div class='item-img-content'>
+      <%= image_tag(@item.image,class:"item-box-img") %>
+      <%# 商品が売れている場合は、sold outを表示しましょう %>
+    <% if @item.nil? %>
+      <div class='sold-out'>
+        <span>Sold Out!!</span>
+      </div>
+    <% end %>
+      <%# //商品が売れている場合は、sold outを表示しましょう %>
+    </div>
+    <div class="item-price-box">
+      <span class="item-price">
+        <%= @item.price %>
+      </span>
+      <span class="item-postage">
+        <%= @item.fee.name %>
+      </span>
+    </div>
+
+    <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
+  <% if user_signed_in?%>
+   <% if current_user == @item.user %>
+    <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
+    <p class='or-text'>or</p>
+    <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
+    <%# 商品が売れていない場合はこちらを表示しましょう %>
+   <% else %>
+    <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
+    <%# //商品が売れていない場合はこちらを表示しましょう %>
+   <% end %>
+  <% end %>
+    <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
+
+    <div class="item-explain-box">
+      <span><%= @item.text %></span>
+    </div>
+    <table class="detail-table">
+      <tbody>
+        <tr>
+          <th class="detail-item">出品者</th>
+          <td class="detail-value"><%= @item.user.nick_name %></td>
+        </tr>
+        <tr>
+          <th class="detail-item">カテゴリー</th>
+          <td class="detail-value"><%= @item.category.name %></td>
+        </tr>
+        <tr>
+          <th class="detail-item">商品の状態</th>
+          <td class="detail-value"><%= @item.condition.name %></td>
+        </tr>
+        <tr>
+          <th class="detail-item">配送料の負担</th>
+          <td class="detail-value"><%= @item.fee.name %></td>
+        </tr>
+        <tr>
+          <th class="detail-item">発送元の地域</th>
+          <td class="detail-value"><%= @item.prefecture.name %></td>
+        </tr>
+        <tr>
+          <th class="detail-item">発送日の目安</th>
+          <td class="detail-value"><%= @item.send_time.name %></td>
+        </tr>
+      </tbody>
+    </table>
+    <div class="option">
+      <div class="favorite-btn">
+        <%= image_tag "star.png" ,class:"favorite-star-icon" ,width:"20",height:"20"%>
+        <span>お気に入り 0</span>
+      </div>
+      <div class="report-btn">
+        <%= image_tag "flag.png" ,class:"report-flag-icon" ,width:"20",height:"20"%>
+        <span>不適切な商品の通報</span>
+      </div>
+    </div>
+  </div>
+  <%# /商品の概要 %>
+
+  <div class="comment-box">
+    <form>
+      <textarea class="comment-text"></textarea>
+      <p class="comment-warn">
+        相手のことを考え丁寧なコメントを心がけましょう。
+        <br>
+        不快な言葉遣いなどは利用制限や退会処分となることがあります。
+      </p>
+      <button type="submit" class="comment-btn">
+        <%= image_tag "comment.png" ,class:"comment-flag-icon" ,width:"20",height:"25"%>
+        <span>コメントする<span>
+      </button>
+    </form>
+  </div>
+  <div class="links">
+    <a href="#" class="change-item-btn">
+      ＜ 前の商品
+    </a>
+    <a href="#" class="change-item-btn">
+      後ろの商品 ＞
+    </a>
+  </div>
+  <a href="#", class="another-item"><%= @item.category.name %>をもっと見る</a>
+</div>
+
+<%= render "shared/footer" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: "items#index"
-  resources :items, only:[:new, :create]
+  resources :items
 end

--- a/spec/factories/categories.rb
+++ b/spec/factories/categories.rb
@@ -1,5 +1,4 @@
 FactoryBot.define do
   factory :category do
-    
   end
 end

--- a/spec/factories/conditions.rb
+++ b/spec/factories/conditions.rb
@@ -1,5 +1,4 @@
 FactoryBot.define do
   factory :condition do
-    
   end
 end

--- a/spec/factories/fees.rb
+++ b/spec/factories/fees.rb
@@ -1,5 +1,4 @@
 FactoryBot.define do
   factory :fee do
-    
   end
 end

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -1,13 +1,13 @@
 FactoryBot.define do
   factory :item do
-    name          {"ito"}
-    text          {"伊藤です"}
-    category_id   {3}
-    condition_id  {2}
-    fee_id        {2}
-    prefecture_id {5}
-    send_time_id  {2}
-    price         {5000}
-    association :user 
+    name          { 'ito' }
+    text          { '伊藤です' }
+    category_id   { 3 }
+    condition_id  { 2 }
+    fee_id        { 2 }
+    prefecture_id { 5 }
+    send_time_id  { 2 }
+    price         { 5000 }
+    association :user
   end
 end

--- a/spec/factories/prefectures.rb
+++ b/spec/factories/prefectures.rb
@@ -1,5 +1,4 @@
 FactoryBot.define do
   factory :prefecture do
-    
   end
 end

--- a/spec/factories/sends.rb
+++ b/spec/factories/sends.rb
@@ -1,5 +1,4 @@
 FactoryBot.define do
   factory :send do
-    
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,13 +1,13 @@
 FactoryBot.define do
   factory :user do
-    nick_name              {"ito"}
-    email                 {"ito123@com"}
-    password              {"k10287"}
-    password_confirmation {password}
-    last_name             {"伊藤"}
-    first_name            {"大志"}
-    last_reading          {"イトウ"}
-    first_reading         {"タイシ"}
-    birth                 {"1992-10-30"}
+    nick_name { 'ito' }
+    email                 { 'ito123@com' }
+    password              { 'k10287' }
+    password_confirmation { password }
+    last_name             { '伊藤' }
+    first_name            { '大志' }
+    last_reading          { 'イトウ' }
+    first_reading         { 'タイシ' }
+    birth                 { '1992-10-30' }
   end
 end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -1,80 +1,80 @@
 require 'rails_helper'
 RSpec.describe Item, type: :model do
   describe Item do
-   before do
+    before do
       @item = FactoryBot.build(:item)
       @item.image = fixture_file_upload('public/test_image.png')
-   end
-
-   describe '商品出品機能' do
-    context '商品情報の登録がうまくいくとき' do
-      it "各項目が全て存在すれば登録できる" do
-        expect(@item).to be_valid
-      end
     end
 
-    context '商品情報の登録がうまくいかないとき' do
-      it "出品画像が空だと登録できない" do
-        @item.image = nil
-        @item.valid?
-        expect(@item.errors.full_messages).to include("Image can't be blank")
+    describe '商品出品機能' do
+      context '商品情報の登録がうまくいくとき' do
+        it '各項目が全て存在すれば登録できる' do
+          expect(@item).to be_valid
+        end
       end
-      it "商品名が空では登録できない" do
-        @item.name = ""
-        @item.valid?
-        expect(@item.errors.full_messages).to include("Name can't be blank")
-      end
-      it "商品説明が空では登録できない" do
-        @item.text = ""
-        @item.valid?
-        expect(@item.errors.full_messages).to include("Text can't be blank")
-      end
-      it "カテゴリーが'--'では登録できない" do
-        @item.category_id = 1
-        @item.valid?
-        expect(@item.errors.full_messages).to include("Category Select")
-      end
-      it "商品の状態が'--'空では登録できない" do
-        @item.condition_id = 1
-        @item.valid?
-        expect(@item.errors.full_messages).to include("Condition Select")
-      end
-      it "配送料の負担が'--'では登録できない" do
-        @item.fee_id = 1
-        @item.valid?
-        expect(@item.errors.full_messages).to include("Fee Select")
-      end
-      it "発送元の地域が'--'では登録できない" do
-        @item.prefecture_id = 1
-        @item.valid?
-        expect(@item.errors.full_messages).to include("Prefecture Select")
-      end
-      it "発送までの日数が'--'では登録できない" do
-        @item.send_time_id = 1
-        @item.valid?
-        expect(@item.errors.full_messages).to include("Send time Select")
-      end
-      it "価格が空では登録できない" do
-        @item.price = ''
-        @item.valid?
-        expect(@item.errors.full_messages).to include("Price can't be blank")
-      end
-      it "価格が300円未満では登録できない" do
-        @item.price = 299
-        @item.valid?
-        expect(@item.errors.full_messages).to include("Price Out of setting range")
-      end
-      it "価格が10,000,000円以上では登録できない" do
-        @item.price = 10000000
-        @item.valid?
-        expect(@item.errors.full_messages).to include("Price Out of setting range")
-      end
-      it "価格が半角数字以外は登録できない" do
-        @item.price = '３００'
-        @item.valid?
-        expect(@item.errors.full_messages).to include("Price Half-width number")
+
+      context '商品情報の登録がうまくいかないとき' do
+        it '出品画像が空だと登録できない' do
+          @item.image = nil
+          @item.valid?
+          expect(@item.errors.full_messages).to include("Image can't be blank")
+        end
+        it '商品名が空では登録できない' do
+          @item.name = ''
+          @item.valid?
+          expect(@item.errors.full_messages).to include("Name can't be blank")
+        end
+        it '商品説明が空では登録できない' do
+          @item.text = ''
+          @item.valid?
+          expect(@item.errors.full_messages).to include("Text can't be blank")
+        end
+        it "カテゴリーが'--'では登録できない" do
+          @item.category_id = 1
+          @item.valid?
+          expect(@item.errors.full_messages).to include('Category Select')
+        end
+        it "商品の状態が'--'空では登録できない" do
+          @item.condition_id = 1
+          @item.valid?
+          expect(@item.errors.full_messages).to include('Condition Select')
+        end
+        it "配送料の負担が'--'では登録できない" do
+          @item.fee_id = 1
+          @item.valid?
+          expect(@item.errors.full_messages).to include('Fee Select')
+        end
+        it "発送元の地域が'--'では登録できない" do
+          @item.prefecture_id = 1
+          @item.valid?
+          expect(@item.errors.full_messages).to include('Prefecture Select')
+        end
+        it "発送までの日数が'--'では登録できない" do
+          @item.send_time_id = 1
+          @item.valid?
+          expect(@item.errors.full_messages).to include('Send time Select')
+        end
+        it '価格が空では登録できない' do
+          @item.price = ''
+          @item.valid?
+          expect(@item.errors.full_messages).to include("Price can't be blank")
+        end
+        it '価格が300円未満では登録できない' do
+          @item.price = 299
+          @item.valid?
+          expect(@item.errors.full_messages).to include('Price Out of setting range')
+        end
+        it '価格が10,000,000円以上では登録できない' do
+          @item.price = 10_000_000
+          @item.valid?
+          expect(@item.errors.full_messages).to include('Price Out of setting range')
+        end
+        it '価格が半角数字以外は登録できない' do
+          @item.price = '３００'
+          @item.valid?
+          expect(@item.errors.full_messages).to include('Price Half-width number')
+        end
       end
     end
-   end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,134 +1,134 @@
 require 'rails_helper'
 RSpec.describe User, type: :model do
   describe User do
-   before do
+    before do
       @user = FactoryBot.build(:user)
-   end
-
-   describe 'ユーザー新規登録' do
-    context '新規登録がうまくいくとき' do
-      it "各項目が全て存在すれば登録できる" do
-        expect(@user).to be_valid
-      end
     end
 
-    context '新規登録がうまくいかないとき' do
-      it "nicknameが空だと登録できない" do
-        @user.nick_name = ''
-        @user.valid?
-        expect(@user.errors.full_messages).to include("Nick name can't be blank")
+    describe 'ユーザー新規登録' do
+      context '新規登録がうまくいくとき' do
+        it '各項目が全て存在すれば登録できる' do
+          expect(@user).to be_valid
+        end
       end
-      it "emailが空では登録できない" do
-        @user.email = ""
-        @user.valid?
-        expect(@user.errors.full_messages).to include("Email can't be blank")
-      end
-      it "emailは＠がないと登録できない" do
-        @user.email = "k0123com"
-        @user.valid?
-        expect(@user.errors.full_messages).to include("Email is invalid")
-      end
-      it "重複したemailが存在する場合登録できない" do
-        @user.save
-        another_user = FactoryBot.build(:user)
-        another_user.email = @user.email
-        another_user.valid?
-        expect(another_user.errors.full_messages).to include("Email has already been taken")
-      end
-      it "passwordが空では登録できない" do
-        @user.password = ''
-        @user.valid?
-        expect(@user.errors.full_messages).to include("Password can't be blank")
-      end
-      it "passwordが5文字以下であれば登録できない" do
-        @user.password = "k0123"
-        @user.password_confirmation = "k0123"
-        @user.valid?
-        expect(@user.errors.full_messages).to include("Password is too short (minimum is 6 characters)")
-      end
-      it "passwordが数字のみの場合は登録できない" do
-        @user.password = "000000"
-        @user.password_confirmation = "000000"
-        @user.valid?
-        expect(@user.errors.full_messages).to include("Password Include both letters and numbers")
-      end
-      it "passwordが英字のみの場合は登録できない" do
-        @user.password = "kkkkkk"
-        @user.password_confirmation = "kkkkkk"
-        @user.valid?
-        expect(@user.errors.full_messages).to include("Password Include both letters and numbers")
-      end
-      it "passwordが存在してもpassword_confirmationが空では登録できない" do
-        @user.password_confirmation = ""
-        @user.valid?
-        expect(@user.errors.full_messages).to include("Password confirmation doesn't match Password")
-      end
-      it "苗字が空では登録できない" do
-        @user.last_name = ''
-        @user.valid?
-        expect(@user.errors.full_messages).to include("Last name can't be blank")
-      end
-      it "苗字が半角英数字では登録できない" do
-        @user.last_name = 'ito01'
-        @user.valid?
-        expect(@user.errors.full_messages).to include("Last name Full-width characters")
-      end
-      it "名前が空では登録できない" do
-        @user.first_name = ''
-        @user.valid?
-        expect(@user.errors.full_messages).to include("First name can't be blank")
-      end
-      it "名前が半角英数字では登録できない" do
-        @user.first_name = 'taishi02'
-        @user.valid?
-        expect(@user.errors.full_messages).to include("First name Full-width characters")
-      end
-      it "苗字のカナが空では登録できない" do
-        @user.last_reading = ''
-        @user.valid?
-        expect(@user.errors.full_messages).to include("Last reading can't be blank")
-      end
-      it "苗字のカナが半角英数字では登録できない" do
-        @user.last_reading = 'ito'
-        @user.valid?
-        expect(@user.errors.full_messages).to include("Last reading kana Full-width katakana characters")
-      end
-      it "苗字のカナが平仮名では登録できない" do
-        @user.last_reading = 'いとう'
-        @user.valid?
-        expect(@user.errors.full_messages).to include("Last reading kana Full-width katakana characters")
-      end
-      it "苗字のカナが漢字では登録できない" do
-        @user.last_reading = '伊藤'
-        @user.valid?
-        expect(@user.errors.full_messages).to include("Last reading kana Full-width katakana characters")
-      end
-      it "名前のカナが空では登録できない" do
-        @user.first_reading = ''
-        @user.valid?
-        expect(@user.errors.full_messages).to include("First reading can't be blank")
-      end
-      it "名前のカナが半角英数字では登録できない" do
-        @user.first_reading = 'taishi'
-        @user.valid?
-        expect(@user.errors.full_messages).to include("First reading kana Full-width katakana characters")
-      end
-      it "名前のカナが平仮名では登録できない" do
-        @user.first_reading = 'たいし'
-        @user.valid?
-        expect(@user.errors.full_messages).to include("First reading kana Full-width katakana characters")
-      end
-      it "名前のカナが漢字では登録できない" do
-        @user.first_reading = '大志'
-        @user.valid?
-        expect(@user.errors.full_messages).to include("First reading kana Full-width katakana characters")
-      end
-      it "生年月日が空では登録できない" do
-        @user.birth = ''
-        @user.valid?
-        expect(@user.errors.full_messages).to include("Birth can't be blank")
+
+      context '新規登録がうまくいかないとき' do
+        it 'nicknameが空だと登録できない' do
+          @user.nick_name = ''
+          @user.valid?
+          expect(@user.errors.full_messages).to include("Nick name can't be blank")
+        end
+        it 'emailが空では登録できない' do
+          @user.email = ''
+          @user.valid?
+          expect(@user.errors.full_messages).to include("Email can't be blank")
+        end
+        it 'emailは＠がないと登録できない' do
+          @user.email = 'k0123com'
+          @user.valid?
+          expect(@user.errors.full_messages).to include('Email is invalid')
+        end
+        it '重複したemailが存在する場合登録できない' do
+          @user.save
+          another_user = FactoryBot.build(:user)
+          another_user.email = @user.email
+          another_user.valid?
+          expect(another_user.errors.full_messages).to include('Email has already been taken')
+        end
+        it 'passwordが空では登録できない' do
+          @user.password = ''
+          @user.valid?
+          expect(@user.errors.full_messages).to include("Password can't be blank")
+        end
+        it 'passwordが5文字以下であれば登録できない' do
+          @user.password = 'k0123'
+          @user.password_confirmation = 'k0123'
+          @user.valid?
+          expect(@user.errors.full_messages).to include('Password is too short (minimum is 6 characters)')
+        end
+        it 'passwordが数字のみの場合は登録できない' do
+          @user.password = '000000'
+          @user.password_confirmation = '000000'
+          @user.valid?
+          expect(@user.errors.full_messages).to include('Password Include both letters and numbers')
+        end
+        it 'passwordが英字のみの場合は登録できない' do
+          @user.password = 'kkkkkk'
+          @user.password_confirmation = 'kkkkkk'
+          @user.valid?
+          expect(@user.errors.full_messages).to include('Password Include both letters and numbers')
+        end
+        it 'passwordが存在してもpassword_confirmationが空では登録できない' do
+          @user.password_confirmation = ''
+          @user.valid?
+          expect(@user.errors.full_messages).to include("Password confirmation doesn't match Password")
+        end
+        it '苗字が空では登録できない' do
+          @user.last_name = ''
+          @user.valid?
+          expect(@user.errors.full_messages).to include("Last name can't be blank")
+        end
+        it '苗字が半角英数字では登録できない' do
+          @user.last_name = 'ito01'
+          @user.valid?
+          expect(@user.errors.full_messages).to include('Last name Full-width characters')
+        end
+        it '名前が空では登録できない' do
+          @user.first_name = ''
+          @user.valid?
+          expect(@user.errors.full_messages).to include("First name can't be blank")
+        end
+        it '名前が半角英数字では登録できない' do
+          @user.first_name = 'taishi02'
+          @user.valid?
+          expect(@user.errors.full_messages).to include('First name Full-width characters')
+        end
+        it '苗字のカナが空では登録できない' do
+          @user.last_reading = ''
+          @user.valid?
+          expect(@user.errors.full_messages).to include("Last reading can't be blank")
+        end
+        it '苗字のカナが半角英数字では登録できない' do
+          @user.last_reading = 'ito'
+          @user.valid?
+          expect(@user.errors.full_messages).to include('Last reading kana Full-width katakana characters')
+        end
+        it '苗字のカナが平仮名では登録できない' do
+          @user.last_reading = 'いとう'
+          @user.valid?
+          expect(@user.errors.full_messages).to include('Last reading kana Full-width katakana characters')
+        end
+        it '苗字のカナが漢字では登録できない' do
+          @user.last_reading = '伊藤'
+          @user.valid?
+          expect(@user.errors.full_messages).to include('Last reading kana Full-width katakana characters')
+        end
+        it '名前のカナが空では登録できない' do
+          @user.first_reading = ''
+          @user.valid?
+          expect(@user.errors.full_messages).to include("First reading can't be blank")
+        end
+        it '名前のカナが半角英数字では登録できない' do
+          @user.first_reading = 'taishi'
+          @user.valid?
+          expect(@user.errors.full_messages).to include('First reading kana Full-width katakana characters')
+        end
+        it '名前のカナが平仮名では登録できない' do
+          @user.first_reading = 'たいし'
+          @user.valid?
+          expect(@user.errors.full_messages).to include('First reading kana Full-width katakana characters')
+        end
+        it '名前のカナが漢字では登録できない' do
+          @user.first_reading = '大志'
+          @user.valid?
+          expect(@user.errors.full_messages).to include('First reading kana Full-width katakana characters')
+        end
+        it '生年月日が空では登録できない' do
+          @user.birth = ''
+          @user.valid?
+          expect(@user.errors.full_messages).to include("Birth can't be blank")
+        end
       end
     end
-   end
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 ENV['RAILS_ENV'] ||= 'test'
 require File.expand_path('../config/environment', __dir__)
 # Prevent database truncation if the environment is production
-abort("The Rails environment is running in production mode!") if Rails.env.production?
+abort('The Rails environment is running in production mode!') if Rails.env.production?
 require 'rspec/rails'
 # Add additional requires below this line. Rails is not loaded until this point!
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -44,53 +44,51 @@ RSpec.configure do |config|
   # triggering implicit auto-inclusion in groups with matching metadata.
   config.shared_context_metadata_behavior = :apply_to_host_groups
 
-# The settings below are suggested to provide a good initial experience
-# with RSpec, but feel free to customize to your heart's content.
-=begin
-  # This allows you to limit a spec run to individual examples or groups
-  # you care about by tagging them with `:focus` metadata. When nothing
-  # is tagged with `:focus`, all examples get run. RSpec also provides
-  # aliases for `it`, `describe`, and `context` that include `:focus`
-  # metadata: `fit`, `fdescribe` and `fcontext`, respectively.
-  config.filter_run_when_matching :focus
-
-  # Allows RSpec to persist some state between runs in order to support
-  # the `--only-failures` and `--next-failure` CLI options. We recommend
-  # you configure your source control system to ignore this file.
-  config.example_status_persistence_file_path = "spec/examples.txt"
-
-  # Limits the available syntax to the non-monkey patched syntax that is
-  # recommended. For more details, see:
-  #   - http://rspec.info/blog/2012/06/rspecs-new-expectation-syntax/
-  #   - http://www.teaisaweso.me/blog/2013/05/27/rspecs-new-message-expectation-syntax/
-  #   - http://rspec.info/blog/2014/05/notable-changes-in-rspec-3/#zero-monkey-patching-mode
-  config.disable_monkey_patching!
-
-  # Many RSpec users commonly either run the entire suite or an individual
-  # file, and it's useful to allow more verbose output when running an
-  # individual spec file.
-  if config.files_to_run.one?
-    # Use the documentation formatter for detailed output,
-    # unless a formatter has already been configured
-    # (e.g. via a command-line flag).
-    config.default_formatter = "doc"
-  end
-
-  # Print the 10 slowest examples and example groups at the
-  # end of the spec run, to help surface which specs are running
-  # particularly slow.
-  config.profile_examples = 10
-
-  # Run specs in random order to surface order dependencies. If you find an
-  # order dependency and want to debug it, you can fix the order by providing
-  # the seed, which is printed after each run.
-  #     --seed 1234
-  config.order = :random
-
-  # Seed global randomization in this process using the `--seed` CLI option.
-  # Setting this allows you to use `--seed` to deterministically reproduce
-  # test failures related to randomization by passing the same `--seed` value
-  # as the one that triggered the failure.
-  Kernel.srand config.seed
-=end
+  # The settings below are suggested to provide a good initial experience
+  # with RSpec, but feel free to customize to your heart's content.
+  #   # This allows you to limit a spec run to individual examples or groups
+  #   # you care about by tagging them with `:focus` metadata. When nothing
+  #   # is tagged with `:focus`, all examples get run. RSpec also provides
+  #   # aliases for `it`, `describe`, and `context` that include `:focus`
+  #   # metadata: `fit`, `fdescribe` and `fcontext`, respectively.
+  #   config.filter_run_when_matching :focus
+  #
+  #   # Allows RSpec to persist some state between runs in order to support
+  #   # the `--only-failures` and `--next-failure` CLI options. We recommend
+  #   # you configure your source control system to ignore this file.
+  #   config.example_status_persistence_file_path = "spec/examples.txt"
+  #
+  #   # Limits the available syntax to the non-monkey patched syntax that is
+  #   # recommended. For more details, see:
+  #   #   - http://rspec.info/blog/2012/06/rspecs-new-expectation-syntax/
+  #   #   - http://www.teaisaweso.me/blog/2013/05/27/rspecs-new-message-expectation-syntax/
+  #   #   - http://rspec.info/blog/2014/05/notable-changes-in-rspec-3/#zero-monkey-patching-mode
+  #   config.disable_monkey_patching!
+  #
+  #   # Many RSpec users commonly either run the entire suite or an individual
+  #   # file, and it's useful to allow more verbose output when running an
+  #   # individual spec file.
+  #   if config.files_to_run.one?
+  #     # Use the documentation formatter for detailed output,
+  #     # unless a formatter has already been configured
+  #     # (e.g. via a command-line flag).
+  #     config.default_formatter = "doc"
+  #   end
+  #
+  #   # Print the 10 slowest examples and example groups at the
+  #   # end of the spec run, to help surface which specs are running
+  #   # particularly slow.
+  #   config.profile_examples = 10
+  #
+  #   # Run specs in random order to surface order dependencies. If you find an
+  #   # order dependency and want to debug it, you can fix the order by providing
+  #   # the seed, which is printed after each run.
+  #   #     --seed 1234
+  #   config.order = :random
+  #
+  #   # Seed global randomization in this process using the `--seed` CLI option.
+  #   # Setting this allows you to use `--seed` to deterministically reproduce
+  #   # test failures related to randomization by passing the same `--seed` value
+  #   # as the one that triggered the failure.
+  #   Kernel.srand config.seed
 end


### PR DESCRIPTION
# What
・出品された商品詳細の表示機能を実装
・ログインユーザーとそうでないユーザーで詳細表示を変更
# Why
・出品された商品を簡易に閲覧するため。
・他ユーザーが商品詳細の編集、削除を行うことを避けるため。